### PR TITLE
Fix GitHub Pipeline for blog downloads

### DIFF
--- a/aiotasks/tasks/context.py
+++ b/aiotasks/tasks/context.py
@@ -54,6 +54,9 @@ class AsyncWaitContextManager:
         self.args: tuple[Any, ...] = args[5:]
         self.kwargs: dict[str, Any] = kwargs
 
+        # Generate and store task_id for this task
+        self.task_id: str = generate_task_id() if self.celery_compat else uuid.uuid4().hex
+
     @abc.abstractmethod
     def __await__(self) -> Any:  # pragma: no cover
         """Await implementation for direct task submission."""
@@ -98,7 +101,7 @@ class AsyncWaitContextManager:
         Supports both AioTasks native format and Celery Protocol v2 format.
 
         Args:
-            task_id: Unique identifier for the task (generated if not provided)
+            task_id: Unique identifier for the task (uses stored task_id if not provided)
             function_name: Name of the function to execute
             args: Positional arguments for the function
             kwargs: Keyword arguments for the function
@@ -107,7 +110,7 @@ class AsyncWaitContextManager:
             Serialized message as bytes (Celery or AioTasks format)
         """
         if task_id is None:
-            task_id = generate_task_id() if self.celery_compat else uuid.uuid4().hex
+            task_id = self.task_id
 
         if function_name is None:
             function_name = self.function_name


### PR DESCRIPTION
- Add task_id as an instance attribute in AsyncWaitContextManager
- Use stored task_id in build_delay_message instead of generating new one
- This allows tests and code to access the task_id via ctx.task_id
- Fixes integration tests that depend on accessing task_id from context

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Store task_id on AsyncWaitContextManager and default build_delay_message to the stored ID.
> 
> - **Tasks/Context** (`aiotasks/tasks/context.py`):
>   - Add `self.task_id` generated at init (Celery-compatible or UUID) to `AsyncWaitContextManager`.
>   - `build_delay_message` now defaults `task_id` to `self.task_id` instead of generating a new one.
>   - Update docstrings to reflect stored `task_id` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69d32f1f3264f8a403c7a5ec8d9c54e0920afa8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->